### PR TITLE
Admin can edit information snippets

### DIFF
--- a/cypress/fixtures/single_information.json
+++ b/cypress/fixtures/single_information.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "pinned": true,
+  "publish": true,
+  "header": "Item-0",
+  "description": "Often just simple changes aimed at meeting the needs of local communities can be very effective at encouraging increased self care.",
+  "link": "https://www.netdoctor.co.uk/health-services/nhs/a4489/what-is-the-nhs/"
+}

--- a/cypress/integration/adminCanPublishAndPinInformation.feature.js
+++ b/cypress/integration/adminCanPublishAndPinInformation.feature.js
@@ -12,15 +12,15 @@ describe('Admin Can Use information Dashboard', () => {
         cy.intercept('GET', '**/app_data', {
           fixture: 'app_data.json',
         })
-        cy.intercept('POST', '**/information/**', {
+        cy.intercept('PUT', '**/information/**', {
           statusCode: 200,
           body: {
-            message: 'Information has been updated',
+            message: 'Updated successfully',
           },
         })
 
-        TestHelpers.sizeParameters(size)
         cy.visit('/')
+        TestHelpers.sizeParameters(size)
         TestHelpers.authenticate()
         const selection = 'information-edit'
         TestHelpers.sizeCase(size, selection)
@@ -38,33 +38,33 @@ describe('Admin Can Use information Dashboard', () => {
                 'contain.text',
                 'Often just simple changes'
               )
-              cy.get('[data-cy=action]').should('contain.text', 'Placeholder')
+              cy.get('[data-cy=action]').should('contain.text', 'Edit')
             })
         })
       })
 
       context('successfully, by clicking `publish` switch', () => {
         it('is expected to show success message', () => {
-          cy.get('[data-cy=publish-2]').click()
+          cy.get('[data-cy=publish-1]').click()
           cy.get('[data-cy=snack-content]').should(
             'contain',
-            'Information has been updated'
+            'Updated successfully'
           )
         })
       })
 
       context('successfully, by clicking `pinned` switch', () => {
         it('is expected to show success message', () => {
-          cy.get('[data-cy=pinned-2]').click()
+          cy.get('[data-cy=pinned-1]').click()
           cy.get('[data-cy=snack-content]').should(
             'contain',
-            'Information has been updated'
+            'Updated successfully'
           )
         })
       })
       context('unsuccessfully', () => {
         beforeEach(() => {
-          cy.intercept('POST', '**/information/**', {
+          cy.intercept('PUT', '**/information/**', {
             statusCode: 400,
             body: {
               error_message: 'An error occurred',

--- a/cypress/integration/adminCanPublishAndPinInformation.feature.js
+++ b/cypress/integration/adminCanPublishAndPinInformation.feature.js
@@ -1,0 +1,97 @@
+/* eslint-disable no-undef */
+import sizes from '../support/index'
+import TestHelpers from '../support/testhelper'
+
+describe('Admin Can Use information Dashboard', () => {
+  sizes.forEach((size) => {
+    describe(`admin can navigate to information dashboard on ${size}`, () => {
+      beforeEach(() => {
+        cy.intercept('GET', '**/information', {
+          fixture: 'information_items.json',
+        })
+        cy.intercept('GET', '**/app_data', {
+          fixture: 'app_data.json',
+        })
+        cy.intercept('POST', '**/information/**', {
+          statusCode: 200,
+          body: {
+            message: 'Information has been updated',
+          },
+        })
+
+        TestHelpers.sizeParameters(size)
+        cy.visit('/')
+        TestHelpers.authenticate()
+        const selection = 'information-edit'
+        TestHelpers.sizeCase(size, selection)
+      })
+      it('is expected to show a table with list of all information snippets', () => {
+        cy.get('[data-cy=information-table]').within(() => {
+          cy.get('[data-cy=information]')
+            .should('have.length', 10)
+            .first()
+            .within(() => {
+              cy.get('[data-cy=status]').should('contain.text', 'Published')
+              cy.get('[data-cy=pinned]').should('contain.text', 'Pinned')
+              cy.get('[data-cy=header]').should('contain.text', 'Item-0')
+              cy.get('[data-cy=description]').should(
+                'contain.text',
+                'Often just simple changes'
+              )
+              cy.get('[data-cy=action]').should('contain.text', 'Placeholder')
+            })
+        })
+      })
+
+      context('successfully, by clicking `publish` switch', () => {
+        it('is expected to show success message', () => {
+          cy.get('[data-cy=publish-2]').click()
+          cy.get('[data-cy=snack-content]').should(
+            'contain',
+            'Information has been updated'
+          )
+        })
+      })
+
+      context('successfully, by clicking `pinned` switch', () => {
+        it('is expected to show success message', () => {
+          cy.get('[data-cy=pinned-2]').click()
+          cy.get('[data-cy=snack-content]').should(
+            'contain',
+            'Information has been updated'
+          )
+        })
+      })
+      context('unsuccessfully', () => {
+        beforeEach(() => {
+          cy.intercept('POST', '**/information/**', {
+            statusCode: 400,
+            body: {
+              error_message: 'An error occurred',
+            },
+          })
+        })
+
+        context('unsuccessfully, by clicking `publish` switch', () => {
+          it('is expected to show error message', () => {
+            cy.get('[data-cy=publish-1]').click()
+            cy.get('[data-cy=snack-content]').should(
+              'contain',
+              'An error occurred'
+            )
+          })
+        })
+
+        context('unsuccessfully, by clicking `pinned` switch', () => {
+          it('is expected to show error message', () => {
+            cy.get('[data-cy=pinned-1]').click()
+            cy.get('[data-cy=snack-content]').should(
+              'contain',
+              'An error occurred'
+            )
+          })
+        })
+      })
+    })
+  })
+})

--- a/cypress/integration/adminCanUseInformationDashboard.feature.js
+++ b/cypress/integration/adminCanUseInformationDashboard.feature.js
@@ -12,12 +12,6 @@ describe('Admin Can Use information Dashboard', () => {
         cy.intercept('GET', '**/app_data', {
           fixture: 'app_data.json',
         })
-        cy.intercept('POST', '**/information/**', {
-          statusCode: 200,
-          body: {
-            message: 'Information has been updated',
-          },
-        })
 
         TestHelpers.sizeParameters(size)
         cy.visit('/')
@@ -38,28 +32,8 @@ describe('Admin Can Use information Dashboard', () => {
                 'contain.text',
                 'Often just simple changes'
               )
-              cy.get('[data-cy=action]').should('contain.text', 'Placeholder')
+              cy.get('[data-cy=action]').should('contain.text', 'Edit')
             })
-        })
-      })
-
-      context('successfully, by clicking `publish` switch', () => {
-        it('is expected to show success message', () => {
-          cy.get('[data-cy=publish-2]').click()
-          cy.get('[data-cy=snack-content]').should(
-            'contain',
-            'Information has been updated'
-          )
-        })
-      })
-
-      context('successfully, by clicking `pinned` switch', () => {
-        it('is expected to show success message', () => {
-          cy.get('[data-cy=pinned-2]').click()
-          cy.get('[data-cy=snack-content]').should(
-            'contain',
-            'Information has been updated'
-          )
         })
       })
 
@@ -77,52 +51,20 @@ describe('Admin Can Use information Dashboard', () => {
         it('is expected to be able to update the information header, description and link', () => {
           cy.get('[data-cy=info-container]').within(() => {
             cy.get('[data-cy=info-header]')
-              .find('input')
               .clear()
               .type('This is the new Header for this information')
+            cy.get('[data-cy=info-description]')
+              .clear()
+              .type(
+                'This is the new text for this information, which might be this long but max length is 300 characters'
+              )
+            cy.get('[data-cy=info-link]').clear().type('www.klockren.se')
           })
-          cy.get('[data-cy=info-description]')
-            .clear()
-            .type(
-              'This is the new text for this information, which might be this long but max length is 300 characters'
-            )
-          cy.get('[data-cy=info-description]').clear().type('www.klockren.se')
           cy.get('[data-cy=submit-button]').click()
           cy.get('[data-cy=success-message]').should(
             'contain',
             'The information has been successfully updated.'
           )
-        })
-      })
-
-      context('unsuccessfully', () => {
-        beforeEach(() => {
-          cy.intercept('POST', '**/information/**', {
-            statusCode: 400,
-            body: {
-              error_message: 'An error occurred',
-            },
-          })
-        })
-
-        context('unsuccessfully, by clicking `publish` switch', () => {
-          it('is expected to show error message', () => {
-            cy.get('[data-cy=publish-1]').click()
-            cy.get('[data-cy=snack-content]').should(
-              'contain',
-              'An error occurred'
-            )
-          })
-        })
-
-        context('unsuccessfully, by clicking `pinned` switch', () => {
-          it('is expected to show error message', () => {
-            cy.get('[data-cy=pinned-1]').click()
-            cy.get('[data-cy=snack-content]').should(
-              'contain',
-              'An error occurred'
-            )
-          })
         })
       })
     })

--- a/cypress/integration/adminCanUseInformationDashboard.feature.js
+++ b/cypress/integration/adminCanUseInformationDashboard.feature.js
@@ -63,6 +63,38 @@ describe('Admin Can Use information Dashboard', () => {
         })
       })
 
+      context('Admin is able to edit info snippet', () => {
+        beforeEach(() => {
+          cy.intercept('GET', '**/information/1', {
+            fixture: 'single_information.json',
+          })
+          cy.intercept('PUT', '**/information/1', {
+            message: 'The information has been successfully updated.',
+          })
+          cy.get('[data-cy=edit-button]').first().click()
+        })
+
+        it('is expected to be able to update the information header, description and link', () => {
+          cy.get('[data-cy=info-container]').within(() => {
+            cy.get('[data-cy=info-header]')
+              .find('input')
+              .clear()
+              .type('This is the new Header for this information')
+          })
+          cy.get('[data-cy=info-description]')
+            .clear()
+            .type(
+              'This is the new text for this information, which might be this long but max length is 300 characters'
+            )
+          cy.get('[data-cy=info-description]').clear().type('www.klockren.se')
+          cy.get('[data-cy=submit-button]').click()
+          cy.get('[data-cy=success-message]').should(
+            'contain',
+            'The information has been successfully updated.'
+          )
+        })
+      })
+
       context('unsuccessfully', () => {
         beforeEach(() => {
           cy.intercept('POST', '**/information/**', {

--- a/src/components/InformationDashboard/InfoPreviewModal.jsx
+++ b/src/components/InformationDashboard/InfoPreviewModal.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-
 import {
   Button,
   Modal,
@@ -18,6 +17,8 @@ const InfoPreviewModal = ({ informationItem }) => {
   const classes = infoPreview()
   const [open, setOpen] = useState(false)
   const [currentInformation, setCurrentInformation] = useState()
+  const headerMaxLength = 40
+  const descriptionMaxLength = 300
 
   const getInformation = async () => {
     let response = await Information.show(informationItem.id)
@@ -43,6 +44,8 @@ const InfoPreviewModal = ({ informationItem }) => {
         data-cy='edit-button'
         type='button'
         name='edit'
+        variant='contained'
+        color='primary'
         onClick={() => {
           handleOpen()
         }}>
@@ -57,18 +60,20 @@ const InfoPreviewModal = ({ informationItem }) => {
                   <CardContent className={classes.cardContent}>
                     <TextField
                       className={classes.contentField}
-                      label='Header'
+                      label={`Header (max ${headerMaxLength} char.)*`}
                       data-cy='info-header'
                       fullWidth
                       multiline
+                      inputProps={{ maxLength: headerMaxLength }}
                       defaultValue={currentInformation.header}
                     />
                     <TextField
                       className={classes.contentField}
-                      label='Description'
+                      label={`Description (max ${descriptionMaxLength} char.)*`}
                       data-cy='info-description'
                       multiline
                       fullWidth
+                      inputProps={{ maxLength: descriptionMaxLength }}
                       defaultValue={currentInformation.description}
                     />
                     <TextField

--- a/src/components/InformationDashboard/InfoPreviewModal.jsx
+++ b/src/components/InformationDashboard/InfoPreviewModal.jsx
@@ -1,0 +1,124 @@
+import React, { useState } from 'react'
+
+import {
+  Button,
+  Modal,
+  Container,
+  TextField,
+  ButtonGroup,
+  Card,
+  Grid,
+  CardContent,
+} from '@material-ui/core'
+
+import Information from '../../modules/Information'
+import infoPreview from '../../theme/infoPreviewTheme'
+
+const InfoPreviewModal = ({ informationItem, editInformation }) => {
+  const classes = infoPreview()
+  const [open, setOpen] = useState(false)
+  const [currentInformation, setCurrentInformation] = useState()
+
+  const getInformation = async () => {
+    let response = await Information.show(informationItem.id)
+    setCurrentInformation(response)
+  }
+
+  const handleOpen = () => {
+    getInformation()
+    setOpen(true)
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  const handleSubmit = () => {
+    Information.update(informationItem)
+  }
+  return (
+    <>
+      <ButtonGroup
+        size='small'
+        orientation='vertical'
+        variant='contained'
+        color='primary'>
+        <Button
+          data-cy='edit-button'
+          type='button'
+          name='edit'
+          onClick={() => {
+            handleOpen()
+          }}>
+          Edit
+        </Button>
+      </ButtonGroup>
+      {currentInformation && (
+        <>
+          <Modal open={open} className={classes.modal}>
+            <Container data-cy='info-container' className={classes.card}>
+              <Card elevation={2} className={classes.fullHeight}>
+                <Grid container direction='row' className={classes.fullHeight}>
+                  <Grid item sm={10} xs={11}>
+                    <CardContent className={classes.cardContent}>
+                      <TextField
+                        className={classes.contentField}
+                        label='Header'
+                        data-cy='info-header'
+                        fullWidth
+                        multiline
+                        defaultValue={currentInformation.header}
+                      />
+                      <TextField
+                        className={classes.contentField}
+                        label='Description'
+                        data-cy='info-description'
+                        multiline
+                        fullWidth
+                        defaultValue={currentInformation.description}
+                      />
+                      <TextField
+                        className={classes.contentField}
+                        label='Link'
+                        data-cy='info-link'
+                        multiline
+                        fullWidth
+                        defaultValue={currentInformation.link}
+                      />
+                    </CardContent>
+                  </Grid>
+                </Grid>
+              </Card>
+              <ButtonGroup
+                className={classes.buttonsContainer}
+                size='small'
+                variant='text'
+                color='primary'>
+                <Button
+                  className={classes.closeBtn}
+                  variant='contained'
+                  color='primary'
+                  data-cy='close-btn'
+                  type='button'
+                  onClick={handleClose}>
+                  Close
+                </Button>
+                <Button
+                  className={classes.closeBtn}
+                  variant='contained'
+                  color='primary'
+                  type='button'
+                  data-cy='submit-button'
+                  onClick={handleSubmit}>
+                  Submit
+                </Button>
+              </ButtonGroup>
+            </Container>
+          </Modal>
+        </>
+      )}
+    </>
+  )
+}
+
+export default InfoPreviewModal

--- a/src/components/InformationDashboard/InfoPreviewModal.jsx
+++ b/src/components/InformationDashboard/InfoPreviewModal.jsx
@@ -36,6 +36,7 @@ const InfoPreviewModal = ({ informationItem, editInformation }) => {
 
   const handleSubmit = () => {
     Information.update(informationItem)
+    setOpen(false)
   }
   return (
     <>

--- a/src/components/InformationDashboard/InfoPreviewModal.jsx
+++ b/src/components/InformationDashboard/InfoPreviewModal.jsx
@@ -9,6 +9,7 @@ import {
   Card,
   Grid,
   CardContent,
+  Box,
 } from '@material-ui/core'
 
 import Information from '../../modules/Information'
@@ -88,31 +89,29 @@ const InfoPreviewModal = ({ informationItem, editInformation }) => {
                     </CardContent>
                   </Grid>
                 </Grid>
+                <Box
+                  className={classes.buttonsContainer}
+                >
+                  <Button
+                    className={classes.closeBtn}
+                    variant='contained'
+                    color='primary'
+                    data-cy='close-btn'
+                    type='button'
+                    onClick={handleClose}>
+                    Close
+                  </Button>
+                  <Button
+                    className={classes.closeBtn}
+                    variant='contained'
+                    color='primary'
+                    type='button'
+                    data-cy='submit-button'
+                    onClick={handleSubmit}>
+                    Submit
+                  </Button>
+                </Box>
               </Card>
-              <ButtonGroup
-                className={classes.buttonsContainer}
-                size='small'
-                variant='text'
-                color='primary'>
-                <Button
-                  className={classes.closeBtn}
-                  variant='contained'
-                  color='primary'
-                  data-cy='close-btn'
-                  type='button'
-                  onClick={handleClose}>
-                  Close
-                </Button>
-                <Button
-                  className={classes.closeBtn}
-                  variant='contained'
-                  color='primary'
-                  type='button'
-                  data-cy='submit-button'
-                  onClick={handleSubmit}>
-                  Submit
-                </Button>
-              </ButtonGroup>
             </Container>
           </Modal>
         </>

--- a/src/components/InformationDashboard/InfoPreviewModal.jsx
+++ b/src/components/InformationDashboard/InfoPreviewModal.jsx
@@ -5,7 +5,6 @@ import {
   Modal,
   Container,
   TextField,
-  ButtonGroup,
   Card,
   Grid,
   CardContent,
@@ -15,7 +14,7 @@ import {
 import Information from '../../modules/Information'
 import infoPreview from '../../theme/infoPreviewTheme'
 
-const InfoPreviewModal = ({ informationItem, editInformation }) => {
+const InfoPreviewModal = ({ informationItem }) => {
   const classes = infoPreview()
   const [open, setOpen] = useState(false)
   const [currentInformation, setCurrentInformation] = useState()
@@ -40,82 +39,72 @@ const InfoPreviewModal = ({ informationItem, editInformation }) => {
   }
   return (
     <>
-      <ButtonGroup
-        size='small'
-        orientation='vertical'
-        variant='contained'
-        color='primary'>
-        <Button
-          data-cy='edit-button'
-          type='button'
-          name='edit'
-          onClick={() => {
-            handleOpen()
-          }}>
-          Edit
-        </Button>
-      </ButtonGroup>
+      <Button
+        data-cy='edit-button'
+        type='button'
+        name='edit'
+        onClick={() => {
+          handleOpen()
+        }}>
+        Edit
+      </Button>
       {currentInformation && (
-        <>
-          <Modal open={open} className={classes.modal}>
-            <Container data-cy='info-container' className={classes.card}>
-              <Card elevation={2} className={classes.fullHeight}>
-                <Grid container direction='row' className={classes.fullHeight}>
-                  <Grid item sm={10} xs={11}>
-                    <CardContent className={classes.cardContent}>
-                      <TextField
-                        className={classes.contentField}
-                        label='Header'
-                        data-cy='info-header'
-                        fullWidth
-                        multiline
-                        defaultValue={currentInformation.header}
-                      />
-                      <TextField
-                        className={classes.contentField}
-                        label='Description'
-                        data-cy='info-description'
-                        multiline
-                        fullWidth
-                        defaultValue={currentInformation.description}
-                      />
-                      <TextField
-                        className={classes.contentField}
-                        label='Link'
-                        data-cy='info-link'
-                        multiline
-                        fullWidth
-                        defaultValue={currentInformation.link}
-                      />
-                    </CardContent>
-                  </Grid>
+        <Modal open={open} className={classes.modal}>
+          <Container data-cy='info-container' className={classes.card}>
+            <Card elevation={2} className={classes.fullHeight}>
+              <Grid container direction='row' className={classes.fullHeight}>
+                <Grid item sm={10} xs={11}>
+                  <CardContent className={classes.cardContent}>
+                    <TextField
+                      className={classes.contentField}
+                      label='Header'
+                      data-cy='info-header'
+                      fullWidth
+                      multiline
+                      defaultValue={currentInformation.header}
+                    />
+                    <TextField
+                      className={classes.contentField}
+                      label='Description'
+                      data-cy='info-description'
+                      multiline
+                      fullWidth
+                      defaultValue={currentInformation.description}
+                    />
+                    <TextField
+                      className={classes.contentField}
+                      label='Link'
+                      data-cy='info-link'
+                      multiline
+                      fullWidth
+                      defaultValue={currentInformation.link}
+                    />
+                  </CardContent>
                 </Grid>
-                <Box
-                  className={classes.buttonsContainer}
-                >
-                  <Button
-                    className={classes.closeBtn}
-                    variant='contained'
-                    color='primary'
-                    data-cy='close-btn'
-                    type='button'
-                    onClick={handleClose}>
-                    Close
-                  </Button>
-                  <Button
-                    className={classes.closeBtn}
-                    variant='contained'
-                    color='primary'
-                    type='button'
-                    data-cy='submit-button'
-                    onClick={handleSubmit}>
-                    Submit
-                  </Button>
-                </Box>
-              </Card>
-            </Container>
-          </Modal>
-        </>
+              </Grid>
+              <Box className={classes.buttonsContainer}>
+                <Button
+                  className={classes.closeBtn}
+                  variant='contained'
+                  color='primary'
+                  data-cy='close-btn'
+                  type='button'
+                  onClick={handleClose}>
+                  Close
+                </Button>
+                <Button
+                  className={classes.closeBtn}
+                  variant='contained'
+                  color='primary'
+                  type='button'
+                  data-cy='submit-button'
+                  onClick={handleSubmit}>
+                  Submit
+                </Button>
+              </Box>
+            </Card>
+          </Container>
+        </Modal>
       )}
     </>
   )

--- a/src/modules/Information.js
+++ b/src/modules/Information.js
@@ -34,6 +34,33 @@ const Information = {
     }
   },
 
+  async show(id) {
+    try {
+      const response = await axios.get(`/information/${id}`, {
+        headers: headers,
+      })
+      return response.data
+    } catch (error) {
+      errorHandler(error)
+    }
+  },
+
+  async update(information) {
+    let params = { information: information }
+    try {
+      let response = await axios.put(`/information/${information.id}`, params, {
+        headers: headers,
+      })
+      Information.index()
+      store.dispatch({
+        type: 'SET_SUCCESS',
+        payload: response.data.message,
+      })
+    } catch (error) {
+      errorHandler(error)
+    }
+  },
+
   async update_switch(itemId, attr, switchState) {
     try {
       await axios.put(`/information/${itemId}`, {

--- a/src/modules/Information.js
+++ b/src/modules/Information.js
@@ -45,12 +45,16 @@ const Information = {
     }
   },
 
-  async update(information_item) {
-    let params = { information: information_item }
+  async update(informationItem) {
+    let params = { information: informationItem }
     try {
-      let response = await axios.put(`/information/${information_item.id}`, params, {
-        headers: headers,
-      })
+      let response = await axios.put(
+        `/information/${informationItem.id}`,
+        params,
+        {
+          headers: headers,
+        }
+      )
       Information.index()
       store.dispatch({
         type: 'SET_SUCCESS',

--- a/src/modules/Information.js
+++ b/src/modules/Information.js
@@ -45,10 +45,10 @@ const Information = {
     }
   },
 
-  async update(information) {
-    let params = { information: information }
+  async update(information_item) {
+    let params = { information: information_item }
     try {
-      let response = await axios.put(`/information/${information.id}`, params, {
+      let response = await axios.put(`/information/${information_item.id}`, params, {
         headers: headers,
       })
       Information.index()

--- a/src/theme/infoPreviewTheme.js
+++ b/src/theme/infoPreviewTheme.js
@@ -1,0 +1,18 @@
+import { makeStyles } from '@material-ui/core'
+
+const infoPreview = makeStyles((theme) => ({
+  modal: {
+    overflow: 'scroll',
+  },
+  card: {
+    minHeight: "148px",
+  },
+  fullHeight: {
+    height: "100%",
+  },
+  cardContent: {
+    padding: "30px 20px",
+  },
+}))
+
+export default infoPreview

--- a/src/theme/infoPreviewTheme.js
+++ b/src/theme/infoPreviewTheme.js
@@ -13,6 +13,18 @@ const infoPreview = makeStyles((theme) => ({
   cardContent: {
     padding: "30px 20px",
   },
+  contentField: {
+    margin: "30px 20px",
+  },
+  buttonsContainer: {
+    display: 'flex',
+    direction: 'row',
+    justifyContent: 'space-between',
+  },
+  closeBtn: {
+    margin: '40px',
+    borderRadius: '5px',
+  },
 }))
 
 export default infoPreview

--- a/src/theme/infoPreviewTheme.js
+++ b/src/theme/infoPreviewTheme.js
@@ -3,6 +3,7 @@ import { makeStyles } from '@material-ui/core'
 const infoPreview = makeStyles((theme) => ({
   modal: {
     overflow: 'scroll',
+    marginTop: '40px',
   },
   card: {
     minHeight: "148px",

--- a/src/views/InformationCreation.jsx
+++ b/src/views/InformationCreation.jsx
@@ -25,6 +25,7 @@ const InformationCreation = () => {
     description: '',
     link: '',
   })
+  const headerMaxLength = 40
   const descriptionMaxLength = 300
 
   const handleChange = (event) => {
@@ -95,8 +96,9 @@ const InformationCreation = () => {
           variant='outlined'
           fullWidth
           required
+          label={`header (max ${headerMaxLength} char.)`}
+          inputProps={{ maxLength: headerMaxLength }}
           id='standard-required'
-          label='Header'
           type='string'
           name='header'
           value={info.header}
@@ -111,7 +113,7 @@ const InformationCreation = () => {
           required
           multiline
           minRows={8}
-          label={`description (max ${descriptionMaxLength} char.)*`}
+          label={`description (max ${descriptionMaxLength} char.)`}
           inputProps={{ maxLength: descriptionMaxLength }}
           id='standard-required'
           type='text'

--- a/src/views/InformationDashboard.jsx
+++ b/src/views/InformationDashboard.jsx
@@ -62,8 +62,8 @@ const InformationDashboard = () => {
 
   const tableRows =
     information &&
-    information.map((information_item) => {
-      const { id, header, description, publish, pinned } = information_item
+    information.map((informationItem) => {
+      const { id, header, description, publish, pinned } = informationItem
       return (
         <StyledTableRow data-cy='information' key={id}>
           <StyledTableCell
@@ -112,7 +112,7 @@ const InformationDashboard = () => {
             {description}
           </StyledTableCell>
           <StyledTableCell data-cy='action'>
-            <InfoPreviewModal information={information} />
+            <InfoPreviewModal informationItem={informationItem} />
           </StyledTableCell>
         </StyledTableRow>
       )

--- a/src/views/InformationDashboard.jsx
+++ b/src/views/InformationDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { withStyles } from '@material-ui/core/styles'
 import {
@@ -15,6 +15,7 @@ import {
 
 import Information from '../modules/Information'
 import Switches from '../components/InformationDashboard/Switches'
+import InfoPreviewModal from '../components/InformationDashboard/InfoPreviewModal'
 import informationDashboard from '../theme/informationDashboardTheme'
 
 const StyledTableCell = withStyles((theme) => ({
@@ -55,6 +56,7 @@ const InformationDashboard = () => {
       <StyledTableCell align='left'>Pinned</StyledTableCell>
       <StyledTableCell align='left'>Header</StyledTableCell>
       <StyledTableCell align='left'>Description</StyledTableCell>
+      <StyledTableCell align='left'>Action</StyledTableCell>
     </StyledTableRow>
   )
 
@@ -69,7 +71,14 @@ const InformationDashboard = () => {
             align='center'
             className={classes.statusCell}>
             <FormControlLabel
-              control={<Switches value={publish} name="publish" itemId={id} rerender={rerender}/>}
+              control={
+                <Switches
+                  value={publish}
+                  name='publish'
+                  itemId={id}
+                  rerender={rerender}
+                />
+              }
               label={
                 <Typography className={classes.switchLabel}>
                   {publish ? 'Published' : 'Hidden'}
@@ -79,8 +88,15 @@ const InformationDashboard = () => {
             />
           </StyledTableCell>
           <StyledTableCell data-cy='pinned' className={classes.statusCell}>
-          <FormControlLabel
-              control={<Switches value={pinned} name="pinned" itemId={id} rerender={rerender}/>}
+            <FormControlLabel
+              control={
+                <Switches
+                  value={pinned}
+                  name='pinned'
+                  itemId={id}
+                  rerender={rerender}
+                />
+              }
               label={
                 <Typography className={classes.switchLabel}>
                   {pinned ? 'Pinned' : 'Other'}
@@ -94,6 +110,9 @@ const InformationDashboard = () => {
           </StyledTableCell>
           <StyledTableCell data-cy='description' className={classes.descCell}>
             {description}
+          </StyledTableCell>
+          <StyledTableCell data-cy='action'>
+            <InfoPreviewModal information={information} />
           </StyledTableCell>
         </StyledTableRow>
       )


### PR DESCRIPTION
### PT: https://www.pivotaltracker.com/story/show/179310156

### Userstory
```
As an admin
In order to edit the information
I want to have an editorial modal
```

### Requested changes
- Add edit modal to info snippets
- Add show and update action
- Put pin/publish test in own file and fixed it from failing

### Image
<img width="1247" alt="Screenshot 2021-09-07 at 15 34 27" src="https://user-images.githubusercontent.com/60035332/132354498-312eea28-9369-491f-b53b-158e2bc5da5e.png">
