### PR TITLE
Fixes navigation bug

### DIFF
--- a/src/modules/AppData.js
+++ b/src/modules/AppData.js
@@ -43,11 +43,13 @@ const AppData = {
         secondary_tabs = tab.secondary_tabs.map((secTab) => {
           return {
             label: secTab.label,
-            link: secTab.ref
+            // should check for .ref attr when form is expanded to include it
+            // current condition assumes all secTabs in services are .ref tabs
+            link: (tab.label === 'services')
               ? `/${_.snakeCase(tab.label)}`
               : `/${_.snakeCase(tab.label)}/${_.snakeCase(secTab.label)}`,
             ref: secTab.ref ? _.kebabCase(secTab.ref) : null,
-            visible: secTab.visible,
+            visible: null,
           }
         })
       }
@@ -58,7 +60,7 @@ const AppData = {
           secondary_tabs.length !== 0
             ? secondary_tabs[1].link
             : `/${_.snakeCase(tab.label)}`,
-        visible: tab.visible,
+        visible: null,
         secondary_tabs: !tab.secondary_tabs ? null : secondary_tabs,
       }
     })


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/179732552
### Problem
On public client services view is inaccessible via navigation menu, it is because secondary tabs for that view are .ref tabs and should point to `/services`, however current navigation form submits `/services/secondary_tab_label` to API, which is fine for other views as they don't have .ref tabs
### Solution
Make exception for secondary tabs on Services view to point to `/services` route