### PR TITLE
info header / body length 

### DIFF
--- a/src/components/InformationDashboard/InfoPreviewModal.jsx
+++ b/src/components/InformationDashboard/InfoPreviewModal.jsx
@@ -19,8 +19,8 @@ const InfoPreviewModal = ({ informationItem }) => {
   const [open, setOpen] = useState(false)
   const [currentInformation, setCurrentInformation] = useState()
   const { control, handleSubmit } = useForm()
-  const headerMaxLength = 40
-  const descriptionMaxLength = 300
+  const headerMaxLength = 600
+  const descriptionMaxLength = 1200
 
   const getInformation = async () => {
     let response = await Information.show(informationItem.id)

--- a/src/views/InformationCreation.jsx
+++ b/src/views/InformationCreation.jsx
@@ -25,8 +25,8 @@ const InformationCreation = () => {
     description: '',
     link: '',
   })
-  const headerMaxLength = 40
-  const descriptionMaxLength = 300
+  const headerMaxLength = 600
+  const descriptionMaxLength = 1200
 
   const handleChange = (event) => {
     setInfo({


### PR DESCRIPTION
pt story: https://www.pivotaltracker.com/story/show/179763106

Adjusts max length a info snippet header and body can be. 

## Screenshots
![newInfoSnippet](https://user-images.githubusercontent.com/63557569/135418891-85311052-d4fa-4cde-be5b-13d360ed4aad.png)
![newInfoSnippetPinned](https://user-images.githubusercontent.com/63557569/135418903-b7e4bb96-f535-4542-ba7b-56fd7b43e3bd.png)


